### PR TITLE
Improve Member and Method Legibility

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -69,13 +69,12 @@ function addSignatureReturns(f) {
     f.signature = '<span class="signature">'+(f.signature || '') + '</span>';
     
     if (returnTypes.length) {
-        f.signature += '<span class="return-symbol glyphicon glyphicon-circle-arrow-right"></span><span class="type-signature returnType">'+(returnTypes.length ? returnTypes.join(' | ') : '')+'</span>';
+        f.signature += '<span class="type-signature">'+(returnTypes.length ? returnTypes.join(' | ') : '')+'</span>';
     }
 }
 
 function addSignatureTypes(f) {
     var types = helper.getSignatureTypes(f);
-    
     f.signature = (f.signature || '') + '<span class="access-signature">'+(types.length? ' :'+types.join('|') : '')+'</span>';
 }
 
@@ -83,7 +82,10 @@ function addAttribs(f) {
     var attribs = helper.getAttribs(f);
 
     if (attribs.length) {
-        f.attribs = '<span class="access-signature ' + (attribs[0] === 'static' ? 'static' : '') + '">' + htmlsafe(attribs.length ? attribs.join(', ') : '') + '</span>';
+        f.attribs = '';
+        attribs.forEach(function(a) {
+            f.attribs += '<span class="access-signature">' + htmlsafe(a) + '</span>'
+        });
     }    
 }
 

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -61,6 +61,9 @@
         }
         .header {
             padding:20px;
+            h2 {
+                font-weight: bold;
+            }
         }
     }
 
@@ -69,40 +72,42 @@
     }
 
     .access-signature {
+        font-weight: normal;
         display: inline-block;
         border-radius: 3px;
         background-color: @colorTextSubtle;
         color: @colorTextInvert;
         font-size: 0.7em;
         padding: 2px 6px;
-        margin-right: 6px;
+        margin-left: 6px;
         &.deprecated {
             background-color: @colorSubtitle;
             font-size: 0.9em;
+        }
+        a {
+            color: @colorTextInvert;
         }
     }
 
     h4.name {
         .type-signature {
-            margin-left: 5px;
             font-weight: normal;
-            font-size: 85%;
+            font-size: 0.8em;
             color: @colorTextSubtle;
+            &:before {
+                content: ' : ';
+                opacity: 0.6;
+            }
         }
 
         .return-symbol {
-            margin-left: 6px;
+            margin: 0 6px;
             color: @colorTextSubtle;
             font-size: 80%;
         }
 
         .share-icon {
             font-size:70%;
-            color: @colorTextSubtle;
-        }
-
-        .returnType {
-            margin-left: 3px;
             color: @colorTextSubtle;
         }
     }
@@ -118,6 +123,7 @@
         }
 
         h2 {
+            font-weight: bold;
             margin-top: 30px;
             margin-bottom: 10px;
             padding-bottom: 10px;
@@ -135,20 +141,12 @@
     dt.tag-source {
         margin-top: 5px;
     }
+    dt.tag-default {
+        color: @colorTextSubtle;
+    }
 
     .nameContainer {
         position: relative;
-        .inherited, .overrides {
-            display: inline-block;
-            border-radius: 3px;
-            background-color: @colorTextSubtle;
-            font-size: 70%;
-            padding: 2px 4px;
-            margin-right: 5px;
-            a {
-                color: @colorTextInvert;
-            }
-        }
 
         .tag-source {
             position: absolute;
@@ -164,17 +162,14 @@
             }
         }
 
-        &.inherited, &.overrides {
-            color: @colorTextSubtle;
-        }
-
         h4 {
+            font-weight: bold;
             padding: 20px 0 0;
             border-top: 1px solid @colorLine;
             .signature {
                 font-weight: normal;
-                font-family: @fontMonospace;
-                font-size: 0.7em;
+                font-size: .8em;
+                padding-left: 0.4em;
             }
         }
     }
@@ -185,6 +180,7 @@
 
         th {
             padding: 3px 3px;
+            color: @colorTextSubtle;
         }
 
         td {
@@ -233,11 +229,20 @@
             line-height: 1.2;
         }
 
+        h1 {
+            font-weight: bold;
+        }
+
         h2 {
+            font-weight: bold;
             margin-top: 30px;
             margin-bottom: 10px;
             padding-bottom: 10px;
             border-bottom: 1px solid @colorTextSubtle;
+        }
+
+        h3 {
+            color: @colorSubtitle;
         }
 
         li {

--- a/tmpl/members.tmpl
+++ b/tmpl/members.tmpl
@@ -4,22 +4,25 @@ var self = this;
 var typeSignature = '';
 
 if (data.type && data.type.names) {
+    typeSignature += '<span class="type-signature type">';
     data.type.names.forEach(function (name) {
-        typeSignature += '<span class="type-signature type ' + name.toLowerCase() + '">' + self.linkto(name, self.htmlsafe(name)) + '</span> ';
+        typeSignature += self.linkto(name, self.htmlsafe(name));
+        typeSignature += ' | ';
     });
+    typeSignature = typeSignature.slice(0, -3) + '</span>';
 }
 ?>
 <dt>
     <div class="nameContainer">
         <h4 class="name" id="<?js= id ?>">
             <a class="share-icon" href="#<?js= id ?>"><span class="glyphicon glyphicon-link"></span></a>
+            <?js= (data.scope === 'static' ? longname : name)  + typeSignature + data.attribs ?>
             <?js if (data.inherited || data.inherits) { ?>
-                <span class="inherited"><?js= this.linkto(data.inherits, 'inherited') ?></span>
+                <span class="access-signature inherited"><?js= this.linkto(data.inherits, 'inherited') ?></span>
             <?js } ?>
             <?js if (data.overrides) { ?>
-                <span class="overrides"><?js= this.linkto(data.overrides, 'overrides') ?></span>
+                <span class="access-signature overrides"><?js= this.linkto(data.overrides, 'overrides') ?></span>
             <?js } ?>
-            <?js= data.attribs + (data.scope === 'static' ? longname : name)  + typeSignature ?>
         </h4>
     </div>
     

--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -3,16 +3,16 @@ var data = obj;
 var self = this;
 ?>
 <dt>
-    <div class="nameContainer<?js if (data.inherited) { ?> inherited<?js } else if (data.overrides) { ?> overrides<?js } ?>">
+    <div class="nameContainer">
         <h4 class="name" id="<?js= id ?>">
             <a class="share-icon" href="#<?js= id ?>"><span class="glyphicon glyphicon-link"></span></a>
+            <?js=  (kind === 'class' ? 'new ' : '') + (data.scope === 'static' ? longname : name) + (kind !== 'event' ? data.signature : '') + data.attribs ?>
             <?js if (data.inherited || data.inherits) { ?>
-                <span class="inherited"><?js= this.linkto(data.inherits, 'inherited') ?></span>
+                <span class="access-signature inherited"><?js= this.linkto(data.inherits, 'inherited') ?></span>
             <?js } ?>
             <?js if (data.overrides) { ?>
-                <span class="overrides"><?js= this.linkto(data.overrides, 'overrides') ?></span>
+                <span class="access-signature overrides"><?js= this.linkto(data.overrides, 'overrides') ?></span>
             <?js } ?>
-            <?js= data.attribs + (kind === 'class' ? 'new ' : '') + (data.scope === 'static' ? longname : name) + (kind !== 'event' ? data.signature : '') ?>
         </h4>
     
         <?js if (data.meta) {?>


### PR DESCRIPTION
Fixes #3 

![screen shot 2017-09-20 at 3 39 23 pm](https://user-images.githubusercontent.com/864393/30663755-bf0ed43a-9e19-11e7-9a0e-a8e453ed3539.png)


### Changed

* The flags (override, inherited, static, constant) are on the right instead of left
* Method and member names are bold
* Inherited method names are now black, not gray
* Class name at the top is bold
* Event signature and return types are the same size and type style