### PR TITLE
Make the global.html page accessible in the navigation

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -241,6 +241,19 @@ function buildNav(members) {
         });
     }
 
+    if (members.globals.length) {
+        nav.push({
+            type: 'namespace',
+            longname: 'global',
+            members: members.globals.filter(function(v) { return v.kind === 'member'; }),
+            methods: members.globals.filter(function(v) { return v.kind === 'function'; }),
+            typedefs: members.globals.filter(function(v) { return v.kind === 'typedef'; }),
+            interfaces: members.globals.filter(function(v) { return v.kind === 'interface'; }),
+            events: members.globals.filter(function(v) { return v.kind === 'event'; }),
+            classes: members.globals.filter(function(v) { return v.kind === 'class'; })
+        });
+    }
+
     if (members.classes.length) {
         _.each(members.classes, function (v) {
             nav.push({

--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -13,7 +13,7 @@
     
 <header>
     <div class="header content-size">
-        <h2><?js if (doc.ancestors && doc.ancestors.length) { ?><span class="ancestors"><?js= doc.ancestors.join('') ?></span><?js } ?><?js= doc.name ?>
+        <h2><?js if (doc.ancestors && doc.ancestors.length) { ?><span class="ancestors"><?js= doc.ancestors.join('') ?></span><?js } ?><?js= doc.name || title ?>
         <?js if (doc.variation) { ?>
             <sup class="variation"><?js= doc.variation ?></sup>
         <?js } ?></h2>

--- a/tmpl/navigation.tmpl
+++ b/tmpl/navigation.tmpl
@@ -17,10 +17,10 @@ var self = this;
             <span class="title <?js if (item.type === 'namespace') { ?>namespace<?js } ?> <?js if (item.deprecated) { ?>status-deprecated<?js } ?>">
                 <?js if (item.type === 'namespace') { ?>
                 <span class="namespaceTag">
-                    <span class="glyphicon glyphicon-folder-open"></span>
+                    <span class="glyphicon glyphicon-<?js= (item.longname === 'global') ? 'globe' : 'folder-open' ?>"></span>
                 </span>
                 <?js } ?>
-                <?js= self.linkto(item.longname, item.longname) ?>
+                <?js= self.linkto(item.longname, item.longname === 'global' ? 'Global' : item.longname) ?>
             </span>
             <ul class="members itemMembers">
             <?js


### PR DESCRIPTION
The template already generates a page global.html containing global symbols, but it is not reachable (and its contents not searchable) unless there are deep links into it somewhere else in the documentation. This commit adds it to the navigation as a namespace-like item. I first had it at the bottom as other JSDoc templates do, but then decided that it optically looked nicer between namespaces and classes.

(I am not sure if this is desired for PixiJS, so it may need to be configurable, but I am not using PixiJS (never even heard of it until yesterday) but using this template for my own library, because I found it to generate the most readable and feature-rich documentation of all the JSDoc templates I have tried.)