### PR TITLE
Support tutorials

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -190,6 +190,27 @@ function attachModuleSymbols(doclets, modules) {
 }
 
 /**
+ * Prepares a tutorial for the navigation sidebar.
+ * @param {object} tutorial
+ * @param {object} parent
+ * @param {object} the tutorial object
+ */
+function prepareTutorialNav(tutorial,parent) {
+    var result = {
+        type: 'tutorial',
+        name: tutorial.name,
+        longname: tutorial.longname,
+        title: tutorial.title,
+        parent: parent
+    };
+
+    result.children = _.map(tutorial.children,function(c) { return prepareTutorialNav(c,tutorial); });
+
+    return result;
+}
+
+
+/**
  * Create the navigation sidebar.
  * @param {object} members The members that will be used to create the sidebar.
  * @param {array<object>} members.classes
@@ -287,14 +308,7 @@ function buildNav(members) {
 
     if (members.tutorials.length) {
         _.each(members.tutorials, function(v) {
-            nav.push({
-                type: 'tutorial',
-                name: v.name,
-                longname: v.longname,
-                title: v.title,
-                children: v.children,
-                parent: v.parent
-            });
+            nav.push(prepareTutorialNav(v));
         });
     }
 

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -42,6 +42,12 @@ $(function () {
     var $currentItem = $nav.find('.item[data-name*="' + filename + '"]:eq(0)');
 
     if ($currentItem.length) {
+        // if a child then show the top level parent and highlight the
+        // current item.
+        if ($currentItem.parents('.children').length) {
+            $currentItem.addClass('current');
+            $currentItem = $currentItem.parents('ul.list>li.item');
+        }
         $currentItem
             .remove()
             .prependTo($list)

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -46,6 +46,8 @@ $(function () {
         // current item.
         if ($currentItem.parents('.children').length) {
             $currentItem.addClass('current');
+            // need to make all children not current
+            $currentItem.find('li.item').addClass('notCurrent');
             $currentItem = $currentItem.parents('ul.list>li.item');
         }
         $currentItem

--- a/src/styles/navigation.less
+++ b/src/styles/navigation.less
@@ -77,10 +77,6 @@
         bottom: 0;
     }
 
-    li:not(.current) > ul.parent {
-      display:none !important;
-    }
-
     li.item {
         margin-bottom: 8px;
         padding-bottom: 8px;
@@ -152,6 +148,9 @@
         li.item {
             border-bottom: none;
             padding-bottom: 0px;
+        }
+        li.current {
+            font-weight: bold;
         }
     }
 

--- a/src/styles/navigation.less
+++ b/src/styles/navigation.less
@@ -77,6 +77,10 @@
         bottom: 0;
     }
 
+    li:not(.current) > ul.parent {
+      display:none !important;
+    }
+
     li.item {
         margin-bottom: 8px;
         padding-bottom: 8px;
@@ -86,6 +90,16 @@
             color: @colorNavLink;
             &:hover {
                 color: #fff;
+            }
+        }
+
+        .parent {
+            margin-top: 6px;
+            .subtitle, .title {
+                display: inline;
+                a {
+                    display:inline;
+                }
             }
         }
         .title {
@@ -131,6 +145,13 @@
 
         .itemMembers li.parent a {
             color: @colorNavSpecial;
+        }
+    }
+
+    .children {
+        li.item {
+            border-bottom: none;
+            padding-bottom: 0px;
         }
     }
 

--- a/src/styles/navigation.less
+++ b/src/styles/navigation.less
@@ -149,6 +149,9 @@
             border-bottom: none;
             padding-bottom: 0px;
         }
+        li.notCurrent {
+            font-weight: normal;
+        }
         li.current {
             font-weight: bold;
         }

--- a/tmpl/navigation.tmpl
+++ b/tmpl/navigation.tmpl
@@ -11,7 +11,7 @@ var self = this;
     </div>
     <ul class="list">
     <?js
-    this.nav.forEach(function (item) {
+    function process(item) {
     ?>
         <li class="item" data-name="<?js= (item.type === 'tutorial' ? 'tutorial-' : '') + item.longname ?>">
             <span class="title <?js if (item.type === 'namespace') { ?>namespace<?js } ?> <?js if (item.deprecated) { ?>status-deprecated<?js } ?>">
@@ -114,18 +114,23 @@ var self = this;
             </ul>
             <?js 
             }
+            if (item.parent) {
+            ?>
+            <ul class="parent itemMembers">
+            <li><span class="subtitle">&lt;&lt;&lt; </span><span class="title"><?js= self.tutoriallink(item.parent.longname) ?></span></li>
+            </ul>
+            <?js
+            }
             if (item.children) {
             ?>
             <ul class="children itemMembers">
             <?js
             if (item.children.length) {
             ?>
-            <span class="subtitle"><?js= item.type === 'tutorial' ? 'Sub Tutorials' : 'Children' ?></span>
+            <span class="subtitle"></span>
             <?js
                 item.children.forEach(function (v) {
-            ?>
-                <li class="parent" data-name="<?js= v.longname ?>"><?js= self.tutoriallink(v.longname) ?></li>
-            <?js
+                    process(v);
                 });
             }
             ?>
@@ -134,6 +139,9 @@ var self = this;
             }
             ?>
         </li>
-    <?js }); ?>
+    <?js }; ?>
+    <?js
+    this.nav.forEach(process);
+    ?>
     </ul>
 </div>

--- a/tmpl/navigation.tmpl
+++ b/tmpl/navigation.tmpl
@@ -114,13 +114,6 @@ var self = this;
             </ul>
             <?js 
             }
-            if (item.parent) {
-            ?>
-            <ul class="parent itemMembers">
-            <li><span class="subtitle">&lt;&lt;&lt; </span><span class="title"><?js= self.tutoriallink(item.parent.longname) ?></span></li>
-            </ul>
-            <?js
-            }
             if (item.children) {
             ?>
             <ul class="children itemMembers">

--- a/tmpl/navigation.tmpl
+++ b/tmpl/navigation.tmpl
@@ -13,15 +13,18 @@ var self = this;
     <?js
     this.nav.forEach(function (item) {
     ?>
-        <li class="item" data-name="<?js= item.longname ?>">
+        <li class="item" data-name="<?js= (item.type === 'tutorial' ? 'tutorial-' : '') + item.longname ?>">
             <span class="title <?js if (item.type === 'namespace') { ?>namespace<?js } ?> <?js if (item.deprecated) { ?>status-deprecated<?js } ?>">
-                <?js if (item.type === 'namespace') { ?>
+                <?js if (item.type === 'namespace' || item.type === 'tutorial') { ?>
                 <span class="namespaceTag">
-                    <span class="glyphicon glyphicon-<?js= (item.longname === 'global') ? 'globe' : 'folder-open' ?>"></span>
+                    <span class="glyphicon glyphicon-<?js= (item.longname === 'global') ? 'globe' : (item.type === 'tutorial' ? 'education' : 'folder-open') ?>"></span>
                 </span>
                 <?js } ?>
-                <?js= self.linkto(item.longname, item.longname === 'global' ? 'Global' : item.longname) ?>
+                <?js= item.type === 'tutorial' ? self.tutoriallink(item.longname) : self.linkto(item.longname, item.longname === 'global' ? 'Global' : item.longname) ?>
             </span>
+            <?js
+            if (item.members) {
+            ?>
             <ul class="members itemMembers">
             <?js
             if (item.members.length) {
@@ -36,6 +39,10 @@ var self = this;
             }
             ?>
             </ul>
+            <?js
+            }
+            if (item.typedefs) {
+            ?>
             <ul class="typedefs itemMembers">
             <?js
             if (item.typedefs.length) {
@@ -50,6 +57,10 @@ var self = this;
             }
             ?>
             </ul>
+            <?js 
+            }
+            if (item.interfaces) {
+            ?>
             <ul class="typedefs itemMembers">
             <?js
             if (item.interfaces.length) {
@@ -64,6 +75,10 @@ var self = this;
             }
             ?>
             </ul>
+            <?js 
+            }
+            if (item.methods) {
+            ?>
             <ul class="methods itemMembers">
             <?js
             if (item.methods.length) {
@@ -79,6 +94,10 @@ var self = this;
             }
             ?>
             </ul>
+            <?js 
+            }
+            if (item.events) {
+            ?>
             <ul class="events itemMembers">
             <?js
             if (item.events.length) {
@@ -93,6 +112,27 @@ var self = this;
             }
             ?>
             </ul>
+            <?js 
+            }
+            if (item.children) {
+            ?>
+            <ul class="children itemMembers">
+            <?js
+            if (item.children.length) {
+            ?>
+            <span class="subtitle"><?js= item.type === 'tutorial' ? 'Sub Tutorials' : 'Children' ?></span>
+            <?js
+                item.children.forEach(function (v) {
+            ?>
+                <li class="parent" data-name="<?js= v.longname ?>"><?js= self.tutoriallink(v.longname) ?></li>
+            <?js
+                });
+            }
+            ?>
+            </ul>
+            <?js
+            }
+            ?>
         </li>
     <?js }); ?>
     </ul>

--- a/tmpl/tutorial.tmpl
+++ b/tmpl/tutorial.tmpl
@@ -1,18 +1,12 @@
 <section>
     
 <header>
-    <?js if (children.length > 0) { ?>
-    <ul><?js
-        var self = this;
-        children.forEach(function(t) { ?>
-        <li><?js= self.tutoriallink(t.name) ?></li>
-    <?js }); ?></ul>
-    <?js } ?>
-
+	<div class="header content-size">
     <h2><?js= header ?></h2>
+    </div>
 </header>  
 
-<article>
+<article class="content-size">
     <?js= content ?>
 </article>
 


### PR DESCRIPTION
Adds support for all levels of tutorials in the navigation bar.

Top level ones are shown by default at the bottom of the list. When a tutorial is current it lists all descendants in the nav bar. Additionally when a child tutorials is current they show a 'go to parent' link in the nav bar.