### PR TITLE
Fix to allow for named exports in PIXI

### DIFF
--- a/plugins/es6-fix.js
+++ b/plugins/es6-fix.js
@@ -2,7 +2,8 @@
 // this gross regex hacks around that issue until it is fixed.
 // See: https://github.com/jsdoc3/jsdoc/issues/1137#issuecomment-174829004
 
-var rgxGross = /(\/\*{2}[\W\w]+?\*\/)\s*export\s+default\s+class\s+([^\s]*)/g;
+var rgxGross = /(\/\*{2}[\W\w]+?\*\/)\s*export\s+class\s+([^\s]*)/g;
+var rgxGrossDefault = /(\/\*{2}[\W\w]+?\*\/)\s*export\s+default\s+class\s+([^\s]*)/g;
 var grossReplace = 'export default $2;\n\n$1\nclass $2';
 
 // JSDoc has issues with expressing member properties within a class
@@ -29,11 +30,17 @@ exports.handlers = {
         // Fix members not showing up attached to class
         if (namespace && className)
         {
-            // console.log(`${namespace[1]}.${className[2]}`);
             // Replaces "@member {Type}"" with "@member {Type} PIXI.ClassName#prop"
             e.source = e.source.replace(rgxMember, '$1 '+ namespace[1] + '.' + className[2] + '#$4$2$3');
         }
 
-        e.source = e.source.replace(rgxGross, grossReplace);
+        if(e.source.match(rgxGrossDefault))
+        {
+            e.source = e.source.replace(rgxGrossDefault, grossReplace);
+        }
+        else
+        {
+            e.source = e.source.replace(rgxGross, grossReplace);
+        }
     },
 };


### PR DESCRIPTION
Adds and extra check for `export class {NAME}`. 

This fixes issues with building the docs and types with the named exports PR to PIXI  [#6051](https://github.com/pixijs/pixi.js/pull/6051)