### PR TITLE
Fix implemented interface list, broken namespace link

### DIFF
--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -55,10 +55,10 @@
         <?js }); ?></ul>
     <?js } ?>
     
-    <?js if (doc.augments && doc.augments.length) { ?>
+    <?js if (doc.implements && doc.implements.length) { ?>
         <h3 class="subsection-title">Implements</h3>
         
-        <ul><?js doc.augments.forEach(function(a) { ?>
+        <ul><?js doc.implements.forEach(function(a) { ?>
             <li><?js= self.linkto(a, a) ?></li>
         <?js }); ?></ul>
     <?js } ?>
@@ -98,7 +98,7 @@
         <h3 class="subsection-title">Namespaces</h3>
         
         <dl class="clearfix summary-list list-namespaces"><?js namespaces.forEach(function(n) { ?>
-            <dt class="<?js= n.deprecated ? 'status-deprecated' : ''?>"><a href="namespaces.html#<?js= n.longname ?>"><?js= self.linkto(n.longname, n.name) ?></a></dt>
+            <dt class="<?js= n.deprecated ? 'status-deprecated' : ''?>"><?js= self.linkto(n.longname, n.name) ?></dt>
 
             <?js if (n.summary) { ?><dd><?js= n.summary ?></dd><?js } ?>
         <?js }); ?></dl>


### PR DESCRIPTION
The following fix includes 2 changes:

- "Implements" section shows the implemented interfaces (see JsDoc [@implements](https://jsdoc.app/tags-implements.html) tag). The [previous pull request](https://github.com/pixijs/pixi-jsdoc-template/pull/20) from me mistakenly showed the extended classes in the interfaces list. 
 Sorry about that.
 This change now is very similar to the [default JsDoc template](https://github.com/jsdoc/jsdoc/blob/b9706918f6ae738906cab31c2deb93376d62aacb/packages/jsdoc/templates/default/tmpl/details.tmpl#L58-L65) behavior. 

- Namespace definitions in the generated page contained invisible but broken links.
  The [linkTo](https://github.com/jsdoc/jsdoc/blob/b9706918f6ae738906cab31c2deb93376d62aacb/packages/jsdoc/lib/jsdoc/util/templateHelper.js#L376) method already creates an HTML anchor with a correct URL, so an additional one is not needed.