### PR TITLE
Add support for injecting custom styles and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install @pixi/jsdoc-template --save-dev
 ## Usage
 
 If you already have JSDoc system, you can use this project as JSDoc template. More information about JSDoc command-line arguments can be found [here](http://usejsdoc.org/about-commandline.html).
- 
+
 ```bash
 jsdoc -c conf.json -R README.md
 ```
@@ -25,39 +25,45 @@ jsdoc -c conf.json -R README.md
 You can set options for customizing your documentations. Notice the `"template"` field for setting the path to **pixi-jsdoc-template**.
 
 ```json
-"templates": {
-    "applicationName": "Demo",
-    "disqus": "",
-    "googleAnalytics": "",
-    "favicon": "path/to/favicon.png",
-    "openGraph": {
-        "title": "",
-        "type": "website",
-        "image": "",
-        "site_name": "",
-        "url": ""
-    },
-    "meta": {
-        "title": "",
-        "description": "",
-        "keyword": ""
-    },
-    "linenums": true,
-    "source": {
-        "include": [
-            "./src/"
-        ],
-        "includePattern": ".+\\.js(doc)?$",
-        "excludePattern": "(^|\\/|\\\\)_"
-    },
-    "opts": {
-        "encoding": "utf8",
-        "recurse": true,
-        "private": false,
-        "lenient": true,
-        "destination": "./docs",
-        "template": "./node_modules/@pixi/jsdoc-template"
-    }
+{
+  "templates": {
+      "applicationName": "Demo",
+      "disqus": "",
+      "googleAnalytics": "",
+      "favicon": "path/to/favicon.png",
+      "openGraph": {
+          "title": "",
+          "type": "website",
+          "image": "",
+          "site_name": "",
+          "url": ""
+      },
+      "meta": {
+          "title": "",
+          "description": "",
+          "keyword": ""
+      },
+      "linenums": true,
+      "source": {
+          "include": [
+              "./src/"
+          ],
+          "includePattern": ".+\\.js(doc)?$",
+          "excludePattern": "(^|\\/|\\\\)_"
+      },
+      "opts": {
+          "encoding": "utf8",
+          "recurse": true,
+          "private": false,
+          "lenient": true,
+          "destination": "./docs",
+          "template": "./node_modules/@pixi/jsdoc-template"
+      }
+  },
+  "pixi": {
+      "styles": ["path/to/custom/styles.css"],
+      "scripts": ["path/to/custom/script.js"]
+   }
 }
 ```
 

--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -31,7 +31,7 @@
     <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
     <link type="text/css" rel="stylesheet" href="styles/bootstrap.min.css">
     <link type="text/css" rel="stylesheet" href="styles/main.css">
-    
+
     <?js if (env.conf.templates) { ?>
     <script>
     var config = <?js= JSON.stringify(env.conf.templates) ?>;
@@ -43,7 +43,7 @@
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', config.googleAnalytics]);
       _gaq.push(['_trackPageview']);
-    
+
       (function() {
         var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
         ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
@@ -76,5 +76,19 @@
 </div>
 <script>prettyPrint();</script>
 <script src="scripts/main.js"></script>
+<?js if (env.conf.pixi && env.conf.pixi.styles && env.conf.pixi.styles.length) {
+      for (var i = 0; i < env.conf.pixi.styles.length; i++) {
+      ?>
+      <link type="text/css" rel="stylesheet" href="<?js= env.conf.pixi.styles[i] ?>">
+      <?js
+      }
+} ?>
+<?js if (env.conf.pixi && env.conf.pixi.scripts && env.conf.pixi.scripts.length) {
+      for (var i = 0; i < env.conf.pixi.scripts.length; i++) {
+      ?>
+      <script src="<?js= env.conf.pixi.scripts[i] ?>"></script>
+      <?js
+      }
+} ?>
 </body>
 </html>


### PR DESCRIPTION
This allows the consumer to tweak styling and behaviour
by supplying their own custom .css and .js files to get
bundled into the docs when they're built.

Heavily influenced by the approach over at:
https://github.com/clenemt/docdash

Closes #25